### PR TITLE
Add default dtype to constructors and other complex methods to allow flexibility for users

### DIFF
--- a/complexPyTorch/complexFunctions.py
+++ b/complexPyTorch/complexFunctions.py
@@ -22,7 +22,7 @@ from torch.nn.functional import max_pool2d, avg_pool2d, dropout, dropout2d, inte
 from torch import tanh, relu, sigmoid
 
 
-def complex_matmul(A, B):
+def complex_matmul(A, B, dtype=torch.complex64):
     """
     Performs the matrix product between two complex matrices
     """
@@ -30,59 +30,59 @@ def complex_matmul(A, B):
     outp_real = torch.matmul(A.real, B.real) - torch.matmul(A.imag, B.imag)
     outp_imag = torch.matmul(A.real, B.imag) + torch.matmul(A.imag, B.real)
 
-    return outp_real.type(torch.complex64) + 1j * outp_imag.type(torch.complex64)
+    return outp_real.type(dtype) + 1j * outp_imag.type(dtype)
 
 
-def complex_avg_pool2d(inp, *args, **kwargs):
+def complex_avg_pool2d(inp, dtype=torch.complex64, *args, **kwargs):
     """
     Perform complex average pooling.
     """
     absolute_value_real = avg_pool2d(inp.real, *args, **kwargs)
     absolute_value_imag = avg_pool2d(inp.imag, *args, **kwargs)
 
-    return absolute_value_real.type(torch.complex64) + 1j * absolute_value_imag.type(
-        torch.complex64
+    return absolute_value_real.type(dtype) + 1j * absolute_value_imag.type(
+        dtype
     )
 
 
-def complex_normalize(inp):
+def complex_normalize(inp, dtype=torch.complex64):
     """
     Perform complex normalization
     """
     real_value, imag_value = inp.real, inp.imag
     real_norm = (real_value - real_value.mean()) / real_value.std()
     imag_norm = (imag_value - imag_value.mean()) / imag_value.std()
-    return real_norm.type(torch.complex64) + 1j * imag_norm.type(torch.complex64)
+    return real_norm.type(dtype) + 1j * imag_norm.type(dtype)
 
 
-def complex_relu(inp):
-    return relu(inp.real).type(torch.complex64) + 1j * relu(inp.imag).type(
-        torch.complex64
+def complex_relu(inp, dtype=torch.complex64):
+    return relu(inp.real).type(dtype) + 1j * relu(inp.imag).type(
+        dtype
     )
 
 
-def complex_sigmoid(inp):
-    return sigmoid(inp.real).type(torch.complex64) + 1j * sigmoid(inp.imag).type(
-        torch.complex64
+def complex_sigmoid(inp, dtype=torch.complex64):
+    return sigmoid(inp.real).type(dtype) + 1j * sigmoid(inp.imag).type(
+        dtype
     )
 
 
-def complex_tanh(inp):
-    return tanh(inp.real).type(torch.complex64) + 1j * tanh(inp.imag).type(
-        torch.complex64
+def complex_tanh(inp, dtype=torch.complex64):
+    return tanh(inp.real).type(dtype) + 1j * tanh(inp.imag).type(
+        dtype
     )
 
 
-def complex_opposite(inp):
-    return -inp.real.type(torch.complex64) + 1j * (-inp.imag.type(torch.complex64))
+def complex_opposite(inp, dtype=torch.complex64):
+    return -inp.real.type(dtype) + 1j * (-inp.imag.type(dtype))
 
 
-def complex_stack(inp, dim):
+def complex_stack(inp, dim, dtype=torch.complex64):
     inp_real = [x.real for x in inp]
     inp_imag = [x.imag for x in inp]
-    return torch.stack(inp_real, dim).type(torch.complex64) + 1j * torch.stack(
+    return torch.stack(inp_real, dim).type(dtype) + 1j * torch.stack(
         inp_imag, dim
-    ).type(torch.complex64)
+    ).type(dtype)
 
 
 def _retrieve_elements_from_indices(tensor, indices):
@@ -100,6 +100,7 @@ def complex_upsample(
     mode="nearest",
     align_corners=None,
     recompute_scale_factor=None,
+    dtype=torch.complex64
 ):
     """
     Performs upsampling by separately interpolating the real and imaginary part and recombining
@@ -121,7 +122,7 @@ def complex_upsample(
         recompute_scale_factor=recompute_scale_factor,
     )
 
-    return outp_real.type(torch.complex64) + 1j * outp_imag.type(torch.complex64)
+    return outp_real.type(dtype) + 1j * outp_imag.type(dtype)
 
 
 def complex_upsample2(
@@ -131,6 +132,7 @@ def complex_upsample2(
     mode="nearest",
     align_corners=None,
     recompute_scale_factor=None,
+    dtype=torch.complex64
 ):
     """
     Performs upsampling by separately interpolating the amplitude and phase part and recombining
@@ -154,8 +156,8 @@ def complex_upsample2(
     )
 
     return outp_abs * (
-        torch.cos(outp_angle).type(torch.complex64)
-        + 1j * torch.sin(outp_angle).type(torch.complex64)
+        torch.cos(outp_angle).type(dtype)
+        + 1j * torch.sin(outp_angle).type(dtype)
     )
 
 
@@ -167,6 +169,7 @@ def complex_max_pool2d(
     dilation=1,
     ceil_mode=False,
     return_indices=False,
+    dtype=torch.complex64
 ):
     """
     Perform complex max pooling by selecting on the absolute value on the complex values.
@@ -181,15 +184,15 @@ def complex_max_pool2d(
         return_indices=True,
     )
     # performs the selection on the absolute values
-    absolute_value = absolute_value.type(torch.complex64)
+    absolute_value = absolute_value.type(dtype)
     # retrieve the corresponding phase value using the indices
     # unfortunately, the derivative for 'angle' is not implemented
     angle = torch.atan2(inp.imag, inp.real)
     # get only the phase values selected by max pool
     angle = _retrieve_elements_from_indices(angle, indices)
     return absolute_value * (
-        torch.cos(angle).type(torch.complex64)
-        + 1j * torch.sin(angle).type(torch.complex64)
+        torch.cos(angle).type(dtype)
+        + 1j * torch.sin(angle).type(dtype)
     )
 
 


### PR DESCRIPTION
I would like to use this package with higher precision, so I have added the ability to pass dtypes.

I went through all the functions and classes in the package. For each class in complexLayers.py, I added a dtype=torch.complex64 optional argument to the constructor and a self.dtype=dtype class member. In class methods, I replaced torch.complex64 with self.dtype. For each method in complexFunctions.py which uses the dtype at all, I added a dtype=torch.complex64 optional argument and replaced torch.complex64 with dtype in the method body.

Without a testing suite I can't verify nothing broke with confidence, but I used default arguments so that current users do not need to change their function/constructor calls. Pretty sure this should be entirely backward-compatible with existing work.